### PR TITLE
Update utils.py

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -421,8 +421,8 @@ def _normalize_outputs(code1, code2, transform_output=None):
     processed_code1 = []
     processed_code2 = []
 
-    lines1 = code1.split(os.linesep)
-    lines2 = code2.split(os.linesep)
+    lines1 = code1.split('\n')
+    lines2 = code2.split('\n')
 
     for line1, line2 in itertools.zip_longest(lines1, lines2, fillvalue=None):
 


### PR DESCRIPTION
Fix for 'cricket-unttest run all' 922+ Fails [Window] #685

Many test are failing in windows because of line separator issue .we see extra /// or ||| in string output.

As suggested by lielfr
"It seems like the output from javascript does not respect the native line separator difference. Changing it to:
lines1 = code1.split('\n')"

I have tested this and looks good now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ ] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
